### PR TITLE
C# - Updates to BotBuilder SDK 3.5.2

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/AzureModule.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/AzureModule.cs
@@ -41,6 +41,7 @@ using System.Runtime.Serialization.Formatters.Binary;
 using Autofac;
 using Microsoft.Bot.Builder.Dialogs.Internals;
 using Microsoft.Bot.Builder.Internals.Fibers;
+using Microsoft.Bot.Builder.Scorables.Internals;
 using Microsoft.Bot.Connector;
 using Module = Autofac.Module;
 
@@ -150,7 +151,7 @@ namespace Microsoft.Bot.Builder.Azure
 
             // register binary formatter used for binary serialization operation
             builder
-                .Register((c, p) => new BinaryFormatter(c.Resolve<ISurrogateSelector>(), new StreamingContext(StreamingContextStates.All, c.Resolve<Serialization.StoreInstanceByTypeSurrogate.IResolver>(p)))
+                .Register((c, p) => new BinaryFormatter(c.Resolve<ISurrogateSelector>(), new StreamingContext(StreamingContextStates.All, c.Resolve<IResolver>(p)))
                 {
                     AssemblyFormat = FormatterAssemblyStyle.Simple,
                     Binder = c.Resolve<SerializationBinder>()

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/Microsoft.Bot.Builder.Azure.csproj
@@ -51,16 +51,20 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder.History, Version=3.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Builder.History.3.0.2\lib\net46\Microsoft.Bot.Builder.History.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/TableLogger.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/TableLogger.cs
@@ -367,7 +367,7 @@ namespace Microsoft.Bot.Builder.Azure
     /// <summary>
     /// Module for registering a LoggerTable.
     /// </summary>
-    public class TableLoggerModule : Autofac.Module
+    public class TableLoggerModule : Module
     {
         private CloudStorageAccount _account;
         private string _tableName;

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/app.config
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/app.config
@@ -8,11 +8,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.1.0" newVersion="3.5.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.2.0" newVersion="3.5.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/packages.config
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Bot.Builder" version="3.5.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.5.2" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.History" version="3.0.2" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />

--- a/CSharp/Samples/AzureTable/Microsoft.Bot.Sample.AzureTable.csproj
+++ b/CSharp/Samples/AzureTable/Microsoft.Bot.Sample.AzureTable.csproj
@@ -83,12 +83,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/CSharp/Samples/AzureTable/Web.config
+++ b/CSharp/Samples/AzureTable/Web.config
@@ -33,11 +33,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.1.0" newVersion="3.5.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.2.0" newVersion="3.5.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/CSharp/Samples/AzureTable/packages.config
+++ b/CSharp/Samples/AzureTable/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.5.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.5.2" targetFramework="net46" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.1" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net46" />

--- a/CSharp/Samples/DocumentDb/Microsoft.Bot.Sample.DocumentDb.csproj
+++ b/CSharp/Samples/DocumentDb/Microsoft.Bot.Sample.DocumentDb.csproj
@@ -86,12 +86,16 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/CSharp/Samples/DocumentDb/Web.config
+++ b/CSharp/Samples/DocumentDb/Web.config
@@ -33,11 +33,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.1.0" newVersion="3.5.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.4.0.0" newVersion="3.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.2.0" newVersion="3.5.2.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/CSharp/Samples/DocumentDb/packages.config
+++ b/CSharp/Samples/DocumentDb/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.1" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
-  <package id="Microsoft.Bot.Builder" version="3.5.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.5.2" targetFramework="net46" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.1" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net46" />

--- a/CSharp/Tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Azure.Tests/Microsoft.Bot.Builder.Azure.Tests.csproj
@@ -49,16 +49,20 @@
       <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Builder, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Builder, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Bot.Builder.Autofac, Version=3.5.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Builder.Autofac.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Bot.Builder.History, Version=3.0.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Bot.Builder.History.3.0.2\lib\net46\Microsoft.Bot.Builder.History.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Bot.Connector, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.0\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Bot.Connector, Version=3.5.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Bot.Builder.3.5.2\lib\net46\Microsoft.Bot.Connector.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -90,9 +94,9 @@
       <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/CSharp/Tests/Microsoft.Bot.Builder.Azure.Tests/app.config
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Azure.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -16,11 +16,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Connector" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.1.0" newVersion="3.5.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bot.Builder" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.0" newVersion="3.5.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.5.2.0" newVersion="3.5.2.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/CSharp/Tests/Microsoft.Bot.Builder.Azure.Tests/packages.config
+++ b/CSharp/Tests/Microsoft.Bot.Builder.Azure.Tests/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.Azure.DocumentDB" version="1.11.0" targetFramework="net46" />
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Bot.Builder" version="3.5.0" targetFramework="net46" />
+  <package id="Microsoft.Bot.Builder" version="3.5.2" targetFramework="net46" />
   <package id="Microsoft.Bot.Builder.History" version="3.0.2" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
   <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />


### PR DESCRIPTION
Changes
- Update BotBuilder SDK to v3.5.2
- Update IResolver location
- Update C# Samples

TODO:
- Bump BotBuilder-Azure version