### PR TITLE
add enforceTable property to IAzureSqlConfiguration, prevents automatic creation of table when table not found.

### DIFF
--- a/Node/examples/feature-azureSql/app.js
+++ b/Node/examples/feature-azureSql/app.js
@@ -6,6 +6,9 @@ This Bot demonstrates how to use Azure SQL for bot storage.
 -Using Azure SQL
     -Create an Azure SQL database (https://docs.microsoft.com/en-us/azure/sql-database/sql-database-get-started-portal)
     -Replace userName, password, server, database, and table to your preference in the code below.
+    -IMPORTANT: You should create your table before attempting to connect your bot to it. 
+     If you wish for the table to be created if it isn't initially found, you must add the key-value pair `enforceTable: true` to your SQL configuration. See Line 25.
+     The minimal SQL script used to create the table is: `CREATE TABLE your_specified_table_name (id NVARCHAR(200), data NVARCHAR(1000), isCompressed BIT`
     -Set rowCollectionOnRequestCompletion to true to retrieve row content.
     -Run the bot from the command line using "node app.js"
     -Type anything, and the bot will respond showing the text you typed
@@ -20,6 +23,7 @@ var sqlConfig = {
     userName: '<Your-DB-Login>',
     password: '<Your-DB-Login-Password>',
     server: '<Host>',
+    // enforceTable: true, // If this property is not set to true it defaults to false. When false if the specified table is not found, the bot will throw an error.
     options: {
         database: '<DB-Name>',
         table: '<DB-Table>',

--- a/Node/lib/botbuilder-azure.d.ts
+++ b/Node/lib/botbuilder-azure.d.ts
@@ -254,6 +254,11 @@ export interface IAzureSqlConfiguration extends ConnectionConfig {
      * IAzureSqlOptions which extends ConnectionOptions, includes "table" parameter
      */
     options: IAzureSqlOptions;
+    /**
+     * Flag to set if user wishes BotBuilder-Azure to create specified table if it doesn't exist.
+     * By default is set to false.
+     */
+    enforceTable: boolean;
 }
 
 export interface IAzureSqlOptions extends ConnectionOptions {

--- a/Node/src/botbuilder-azure.d.ts
+++ b/Node/src/botbuilder-azure.d.ts
@@ -254,6 +254,11 @@ export interface IAzureSqlConfiguration extends ConnectionConfig {
      * IAzureSqlOptions which extends ConnectionOptions, includes "table" parameter
      */
     options: IAzureSqlOptions;
+    /**
+     * Flag to set if user wishes BotBuilder-Azure to create specified table if it doesn't exist.
+     * By default is set to false.
+     */
+    enforceTable: boolean;
 }
 
 export interface IAzureSqlOptions extends ConnectionOptions {


### PR DESCRIPTION
add enforceTable property to IAzureSqlConfiguration, if property not set to true do not create table (defaults to false). add error message for missing tables