### PR TITLE
Truncate keys over 254 characters

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
@@ -254,19 +254,19 @@ namespace Microsoft.Bot.Builder.Azure
 
         public static string GetEntityKey(IAddress key, BotStoreType botStoreType)
         {
+            string result;
             switch (botStoreType)
             {
                 case BotStoreType.BotConversationData:
-                    var result = $"{key.ChannelId}:conversation{key.ConversationId.SanitizeForAzureKeys()}";
+                    result = $"{key.ChannelId}:conversation{key.ConversationId.SanitizeForAzureKeys()}";
                     return result.Substring(0, Math.Min(result.Length, MAX_KEY_LENGTH));
 
-
                 case BotStoreType.BotUserData:
-                    var result = $"{key.ChannelId}:user{key.UserId.SanitizeForAzureKeys()}";
+                    result = $"{key.ChannelId}:user{key.UserId.SanitizeForAzureKeys()}";
                     return result.Substring(0, Math.Min(result.Length, MAX_KEY_LENGTH));
 
                 case BotStoreType.BotPrivateConversationData:
-                    var result = $"{key.ChannelId}:private{key.ConversationId.SanitizeForAzureKeys()}:{key.UserId.SanitizeForAzureKeys()}";
+                    result = $"{key.ChannelId}:private{key.ConversationId.SanitizeForAzureKeys()}:{key.UserId.SanitizeForAzureKeys()}";
                     return result.Substring(0, Math.Min(result.Length, MAX_KEY_LENGTH));
 
                 default:

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Bot.Builder.Azure
 
     internal class DocDbBotDataEntity
     {
-        internal const int MAX_KEY_LENGTH = 255;
+        internal const int MAX_KEY_LENGTH = 254;
         public DocDbBotDataEntity() { }
 
         internal DocDbBotDataEntity(IAddress key, BotStoreType botStoreType, BotData botData)

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Bot.Builder.Azure
         /// ResourceToken obtained from the permission feed for the user.
         /// Using Direct connectivity, wherever possible, is recommended.</remarks>
         public DocumentDbBotDataStore(Uri serviceEndpoint, string authKey, string databaseId = "botdb", string collectionId = "botcollection")
-            : this( new DocumentClient(serviceEndpoint, authKey), databaseId, collectionId) { }
+            : this(new DocumentClient(serviceEndpoint, authKey), databaseId, collectionId) { }
 
         async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType,
             CancellationToken cancellationToken)
@@ -108,7 +108,7 @@ namespace Microsoft.Bot.Builder.Azure
                 // The Resource property of the response, of type IDynamicMetaObjectProvider, has a dynamic nature, 
                 // similar to DynamicTableEntity in Azure storage. When casting to a static type, properties that exist in the static type will be 
                 // populated from the dynamic type.
-                DocDbBotDataEntity entity = (dynamic) response.Resource;
+                DocDbBotDataEntity entity = (dynamic)response.Resource;
                 return new BotData(response?.Resource.ETag, entity?.Data);
             }
             catch (DocumentClientException e)
@@ -118,7 +118,7 @@ namespace Microsoft.Bot.Builder.Azure
                     return new BotData(string.Empty, null);
                 }
 
-                throw new HttpException(e.StatusCode.HasValue ? (int) e.StatusCode.Value : 0, e.Message, e);
+                throw new HttpException(e.StatusCode.HasValue ? (int)e.StatusCode.Value : 0, e.Message, e);
             }
         }
 
@@ -239,6 +239,7 @@ namespace Microsoft.Bot.Builder.Azure
 
     internal class DocDbBotDataEntity
     {
+        internal const int MAX_KEY_LENGTH = 255;
         public DocDbBotDataEntity() { }
 
         internal DocDbBotDataEntity(IAddress key, BotStoreType botStoreType, BotData botData)
@@ -256,13 +257,17 @@ namespace Microsoft.Bot.Builder.Azure
             switch (botStoreType)
             {
                 case BotStoreType.BotConversationData:
-                    return $"{key.ChannelId}:conversation{key.ConversationId.SanitizeForAzureKeys()}";
+                    var result = $"{key.ChannelId}:conversation{key.ConversationId.SanitizeForAzureKeys()}";
+                    return result.Substring(0, Math.Min(result.Length, MAX_KEY_LENGTH));
+
 
                 case BotStoreType.BotUserData:
-                    return $"{key.ChannelId}:user{key.UserId.SanitizeForAzureKeys()}";
+                    var result = $"{key.ChannelId}:user{key.UserId.SanitizeForAzureKeys()}";
+                    return result.Substring(0, Math.Min(result.Length, MAX_KEY_LENGTH));
 
                 case BotStoreType.BotPrivateConversationData:
-                    return $"{key.ChannelId}:private{key.ConversationId.SanitizeForAzureKeys()}:{key.UserId.SanitizeForAzureKeys()}";
+                    var result = $"{key.ChannelId}:private{key.ConversationId.SanitizeForAzureKeys()}:{key.UserId.SanitizeForAzureKeys()}";
+                    return result.Substring(0, Math.Min(result.Length, MAX_KEY_LENGTH));
 
                 default:
                     throw new ArgumentException("Unsupported bot store type!");


### PR DESCRIPTION
Intended to address issue #32 where keys for msteams private conversations can be greater than 254 characters.  Since this will only change keys that couldn't have been written in the first place, I don't envision any backwards compat issues.  