### PR TITLE
Provide more information when exceptions are thrown

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/TableBotDataStore.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/TableBotDataStore.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Bot.Builder.Azure
             }
             catch (StorageException err)
             {
-                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage);
+                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage, err);
             }
         }
 
@@ -159,9 +159,9 @@ namespace Microsoft.Bot.Builder.Azure
             catch (StorageException err)
             {
                 if ((HttpStatusCode)err.RequestInformation.HttpStatusCode == HttpStatusCode.Conflict)
-                    throw new HttpException((int)HttpStatusCode.PreconditionFailed, err.RequestInformation.HttpStatusMessage);
+                    throw new HttpException((int)HttpStatusCode.PreconditionFailed, err.RequestInformation.HttpStatusMessage, err);
 
-                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage);
+                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage, err);
             }
         }
 

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/TableBotDataStore2.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/TableBotDataStore2.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Bot.Builder.Azure
             }
             catch (StorageException err)
             {
-                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage);
+                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage, err);
             }
         }
 
@@ -184,9 +184,9 @@ namespace Microsoft.Bot.Builder.Azure
             catch (StorageException err)
             {
                 if ((HttpStatusCode)err.RequestInformation.HttpStatusCode == HttpStatusCode.Conflict)
-                    throw new HttpException((int)HttpStatusCode.PreconditionFailed, err.RequestInformation.HttpStatusMessage);
+                    throw new HttpException((int)HttpStatusCode.PreconditionFailed, err.RequestInformation.HttpStatusMessage, err);
 
-                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage);
+                throw new HttpException(err.RequestInformation.HttpStatusCode, err.RequestInformation.HttpStatusMessage, err);
             }
         }
 


### PR DESCRIPTION
Including the `StorageException` as the innerException with the `HttpException` that is thrown. RIght now we are not providing any details. Relates to #79