### PR TITLE
Updating maxDataLength in `Const.ts`

### DIFF
--- a/Node/src/Consts.ts
+++ b/Node/src/Consts.ts
@@ -32,7 +32,7 @@
 //
 
 export var developmentConnectionString = 'UseDevelopmentStorage=true';
-export var maxDataLength = 65000;
+export var maxDataLength = 95000;
 
 export var Fields = {
     UserDataField: 'userData',


### PR DESCRIPTION
Current bot builder architecture limits responses to be under 65000 bytes. With answers that have images, it makes more sense to increase the limit to a higher number