### PR TITLE
Fix CreateDocumentQuery options due to cross partition error

### DIFF
--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Bot.Builder.Azure
                                                     new SqlParameter(entityKeyParameterName, entityKey)
                                                 });
                 var collectionUri = UriFactory.CreateDocumentCollectionUri(databaseId, collectionId);
-                var query = documentClient.CreateDocumentQuery(collectionUri, querySpec)
+                var feedOption = new FeedOptions { EnableCrossPartitionQuery = true };
+                var query = documentClient.CreateDocumentQuery(collectionUri, querySpec, feedOption)
                                           .AsDocumentQuery();
                 var feedResponse = await query.ExecuteNextAsync<Document>(CancellationToken.None);
                 Document document = feedResponse.FirstOrDefault();

--- a/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
+++ b/CSharp/Library/Microsoft.Bot.Builder.Azure/DocumentDbBotDataStore.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Bot.Builder.Azure
         private readonly IDocumentClient documentClient;
         private readonly string databaseId;
         private readonly string collectionId;
+        private readonly bool enableCrossPartitionQuery;
 
         /// <summary>
         /// Creates an instance of the <see cref="IBotDataStore{T}"/> that uses the Azure DocumentDb.
@@ -69,7 +70,8 @@ namespace Microsoft.Bot.Builder.Azure
         /// <param name="documentClient">The DocumentDb client to use.</param>
         /// <param name="databaseId">The name of the DocumentDb database to use.</param>
         /// <param name="collectionId">The name of the DocumentDb collection to use.</param>
-        public DocumentDbBotDataStore(IDocumentClient documentClient, string databaseId = "botdb", string collectionId = "botcollection")
+        /// <param name="enableCrossPartitionQuery">The query param to execute a cross partition query.</param>
+        public DocumentDbBotDataStore(IDocumentClient documentClient, string databaseId = "botdb", string collectionId = "botcollection", bool enableCrossPartitionQuery = false)
         {
             SetField.NotNull(out this.databaseId, nameof(databaseId), databaseId);
             SetField.NotNull(out this.collectionId, nameof(collectionId), collectionId);
@@ -77,6 +79,7 @@ namespace Microsoft.Bot.Builder.Azure
             this.documentClient = documentClient;
             this.databaseId = databaseId;
             this.collectionId = collectionId;
+            this.enableCrossPartitionQuery = enableCrossPartitionQuery;
 
             CreateDatabaseIfNotExistsAsync().GetAwaiter().GetResult();
             CreateCollectionIfNotExistsAsync().GetAwaiter().GetResult();
@@ -89,14 +92,15 @@ namespace Microsoft.Bot.Builder.Azure
         /// <param name="authKey">The authorization key or resource token to use to create the client.</param>
         /// <param name="databaseId">The name of the DocumentDb database to use.</param>
         /// <param name="collectionId">The name of the DocumentDb collection to use.</param>
+        /// <param name="enableCrossPartitionQuery">The query param to execute a cross partition query.</param>
         /// <remarks>The service endpoint can be obtained from the Azure Management Portal. If you
         /// are connecting using one of the Master Keys, these can be obtained along with
         /// the endpoint from the Azure Management Portal If however you are connecting as
         /// a specific DocumentDB User, the value passed to authKeyOrResourceToken is the
         /// ResourceToken obtained from the permission feed for the user.
         /// Using Direct connectivity, wherever possible, is recommended.</remarks>
-        public DocumentDbBotDataStore(Uri serviceEndpoint, string authKey, string databaseId = "botdb", string collectionId = "botcollection")
-            : this(new DocumentClient(serviceEndpoint, authKey), databaseId, collectionId) { }
+        public DocumentDbBotDataStore(Uri serviceEndpoint, string authKey, string databaseId = "botdb", string collectionId = "botcollection", bool enableCrossPartitionQuery = false)
+            : this(new DocumentClient(serviceEndpoint, authKey), databaseId, collectionId, enableCrossPartitionQuery) { }
 
         async Task<BotData> IBotDataStore<BotData>.LoadAsync(IAddress key, BotStoreType botStoreType,
             CancellationToken cancellationToken)
@@ -113,7 +117,8 @@ namespace Microsoft.Bot.Builder.Azure
                                                     new SqlParameter(entityKeyParameterName, entityKey)
                                                 });
                 var collectionUri = UriFactory.CreateDocumentCollectionUri(databaseId, collectionId);
-                var feedOption = new FeedOptions { EnableCrossPartitionQuery = true };
+                // execute the cross partition query if enableCrossPartitionQuery is true
+                var feedOption = new FeedOptions { EnableCrossPartitionQuery = enableCrossPartitionQuery };
                 var query = documentClient.CreateDocumentQuery(collectionUri, querySpec, feedOption)
                                           .AsDocumentQuery();
                 var feedResponse = await query.ExecuteNextAsync<Document>(CancellationToken.None);


### PR DESCRIPTION
I added EnableCrossPartitionQuery with FeedOptions in CreateDocumentQuery to prevent cross partition error. Specifically, I improved enableCrossPartitionQuery can be set as an optional parameter due to execute cross-partition queries.

I checked it works correctly in either case of fixed collection or some unlimited (partitioned) collection as below. 
Additionally, the conventional calling code works normally without change.

# SDK Info
- SDK Platform: .NET
- SDK Version: 3 latest

# Issue Description (Reproduction)

Recently, we cannot create Fixed collection of Cosmos DB (SQL API) on Azure Portal.
If we create new collection on Portal and spesify a value other than '/id' as partition key, we got the following error in Microsoft.Bot.Builder.Azure.
And then, the bot always return "Sorry, my bot code is having issue" due to Internal Server Error (500).

> Cross partition query is required but disabled. Please set x-ms-documentdb-query-enablecrosspartition to true, specify x-ms-documentdb-partitionkey, or revise your query to avoid this exception.

# Changed File
DocumentDbBotDataStore.cs

# Call Examples
- var store = new DocumentDbBotDataStore(uri, key, databaseId, collectionId);
  - enableCrossPartitionQuery : false (default / unable cross-partition query)
- var store = new DocumentDbBotDataStore(uri, key, databaseId, collectionId, false);
  - enableCrossPartitionQuery : false (unable cross-partition query)
- var store = new DocumentDbBotDataStore(uri, key, databaseId, collectionId, true);
  - enableCrossPartitionQuery : true (enable cross-partition query)

# References
[FeedOptions.EnableCrossPartitionQuery Property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.client.feedoptions.enablecrosspartitionquery?view=azure-dotnet)

## Similar Issue
- .NET - c# - Cross partition query is required but disabled trouble on DocumentDB data access
https://stackoverflow.com/questions/46170004/net-c-sharp-cross-partition-query-is-required-but-disabled-trouble-on-docum
- v4 issue
https://github.com/Microsoft/botbuilder-dotnet/issues/1247
